### PR TITLE
fix: criação de contrainer e acesso ao php

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -36,7 +36,7 @@ COPY ./conf.d/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 
 RUN wget https://getcomposer.org/composer-1.phar \
     && chmod a+x composer-1.phar \
-    && sudo mv composer-1.phar /usr/local/bin/composer1;
+    && mv composer-1.phar /usr/local/bin/composer1;
 
 ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
 RUN if [ -f $imagemagic_config ] ; then sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config ; else echo did not see file $imagemagic_config ; fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   meece-php:
     build: ./.docker/php
-    container_name: magento-php
+    container_name: meece-php
     ports:
       - "443:443"
     tty: true


### PR DESCRIPTION
Retirada de um *sudo* da linha 39 do arquivo *dockerfile*, que causava erro na build, e troca de nome do container do php de *magento-php* para *meece-php*, baseando-se na linha 21 do *Makefile*. 